### PR TITLE
fix: libheif and simplify packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ RUN \
     bc \
     build-essential \
     cpanminus \
-    g++ \
     git \
     libany-uri-escape-perl \
     libcapture-tiny-perl \
@@ -51,7 +50,6 @@ RUN \
     libtool \
     libtry-tiny-perl \
     libwebp-dev \
-    make \
     meson \
     pkg-config \
     unzip \
@@ -152,7 +150,6 @@ RUN \
     bc \
     build-essential \
     cpanminus \
-    g++ \
     git \
     libany-uri-escape-perl \
     libcapture-tiny-perl \
@@ -163,10 +160,7 @@ RUN \
     libfile-slurper-perl \
     libfile-which-perl \
     libglib2.0-dev \
-    libglib2.0-dev \
     libgsf-1-dev \
-    libgsf-1-dev \
-    libheif-dev \
     libheif-dev \
     libio-socket-ssl-perl \
     libjpeg-dev \
@@ -188,7 +182,6 @@ RUN \
     libtool \
     libtry-tiny-perl \
     libwebp-dev \
-    make \
     meson \
     pkg-config \
     unzip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,38 +17,21 @@ RUN \
     autoconf \
     bc \
     build-essential \
-    cpanminus \
+    cmake \
     git \
-    libany-uri-escape-perl \
-    libcapture-tiny-perl \
+    libdav1d-dev \
+    libde265-dev \
     libexif-dev \
     libexpat1-dev \
-    libffi-checklib-perl \
-    libfile-chdir-perl \
-    libfile-slurper-perl \
-    libfile-which-perl \
     libglib2.0-dev \
     libgsf-1-dev \
-    libheif-dev \
-    libio-socket-ssl-perl \
     libjpeg-dev \
     libjxl-dev \
     libltdl-dev \
-    libmojolicious-perl \
-    libnet-ssleay-perl \
     liborc-0.4-dev \
-    libpath-tiny-perl \
-    libpkgconfig-perl \
     librsvg2-dev \
-    libsort-versions-perl \
     libspng-dev \
-    libterm-table-perl \
-    libtest-fatal-perl \
-    libtest-needs-perl \
-    libtest-warnings-perl \
-    libtest2-suite-perl \
     libtool \
-    libtry-tiny-perl \
     libwebp-dev \
     meson \
     pkg-config \
@@ -60,13 +43,15 @@ RUN \
   apt-get update && \
   apt-get install --no-install-recommends -y \
     intel-media-va-driver-non-free \
+    libdav1d7 \
+    libde265-0 \
     libexif12 \
     libexpat1 \
     libgcc-s1 \
     libglib2.0-0 \
     libgomp1 \
     libgsf-1-114 \
-    libheif1 \
+    libio-compress-brotli-perl \
     libjxl0.7 \
     liblcms2-2 \
     liblqr-1-0 \
@@ -119,10 +104,10 @@ RUN \
   ldconfig /usr/lib/jellyfin-ffmpeg/lib && \
   ln -s /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/bin && \
   ln -s /usr/lib/jellyfin-ffmpeg/ffprobe /usr/bin && \
+  ./build-libheif.sh && \
   ./build-libraw.sh && \
   ./build-imagemagick.sh && \
   ./build-libvips.sh && \
-  ./build-perllib-compress-brotli.sh && \
   mkdir -p \
     /app/immich/server && \
   mv \
@@ -149,38 +134,21 @@ RUN \
     autoconf \
     bc \
     build-essential \
-    cpanminus \
+    cmake \
     git \
-    libany-uri-escape-perl \
-    libcapture-tiny-perl \
+    libdav1d-dev \
+    libde265-dev \
     libexif-dev \
     libexpat1-dev \
-    libffi-checklib-perl \
-    libfile-chdir-perl \
-    libfile-slurper-perl \
-    libfile-which-perl \
     libglib2.0-dev \
     libgsf-1-dev \
-    libheif-dev \
-    libio-socket-ssl-perl \
     libjpeg-dev \
     libjxl-dev \
     libltdl-dev \
-    libmojolicious-perl \
-    libnet-ssleay-perl \
     liborc-0.4-dev \
-    libpath-tiny-perl \
-    libpkgconfig-perl \
     librsvg2-dev \
-    libsort-versions-perl \
     libspng-dev \
-    libterm-table-perl \
-    libtest-fatal-perl \
-    libtest-needs-perl \
-    libtest-warnings-perl \
-    libtest2-suite-perl \
     libtool \
-    libtry-tiny-perl \
     libwebp-dev \
     meson \
     pkg-config \
@@ -192,6 +160,5 @@ RUN \
     /tmp/* \
     /var/tmp/* \
     /var/lib/apt/lists/* \
-    /root/.cpanm \
     /etc/apt/sources.list.d/node.list \
     /usr/share/keyrings/nodesource.gpg

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -16,7 +16,6 @@ RUN \
     bc \
     build-essential \
     cpanminus \
-    g++ \
     git \
     libany-uri-escape-perl \
     libcapture-tiny-perl \
@@ -49,7 +48,6 @@ RUN \
     libtool \
     libtry-tiny-perl \
     libwebp-dev \
-    make \
     meson \
     pkg-config \
     unzip \
@@ -137,7 +135,6 @@ RUN \
     bc \
     build-essential \
     cpanminus \
-    g++ \
     git \
     libany-uri-escape-perl \
     libcapture-tiny-perl \
@@ -148,10 +145,7 @@ RUN \
     libfile-slurper-perl \
     libfile-which-perl \
     libglib2.0-dev \
-    libglib2.0-dev \
     libgsf-1-dev \
-    libgsf-1-dev \
-    libheif-dev \
     libheif-dev \
     libio-socket-ssl-perl \
     libjpeg-dev \
@@ -173,7 +167,6 @@ RUN \
     libtool \
     libtry-tiny-perl \
     libwebp-dev \
-    make \
     meson \
     pkg-config \
     unzip \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -15,38 +15,21 @@ RUN \
     autoconf \
     bc \
     build-essential \
-    cpanminus \
+    cmake \
     git \
-    libany-uri-escape-perl \
-    libcapture-tiny-perl \
+    libdav1d-dev \
+    libde265-dev \
     libexif-dev \
     libexpat1-dev \
-    libffi-checklib-perl \
-    libfile-chdir-perl \
-    libfile-slurper-perl \
-    libfile-which-perl \
     libglib2.0-dev \
     libgsf-1-dev \
-    libheif-dev \
-    libio-socket-ssl-perl \
     libjpeg-dev \
     libjxl-dev \
     libltdl-dev \
-    libmojolicious-perl \
-    libnet-ssleay-perl \
     liborc-0.4-dev \
-    libpath-tiny-perl \
-    libpkgconfig-perl \
     librsvg2-dev \
-    libsort-versions-perl \
     libspng-dev \
-    libterm-table-perl \
-    libtest-fatal-perl \
-    libtest-needs-perl \
-    libtest-warnings-perl \
-    libtest2-suite-perl \
     libtool \
-    libtry-tiny-perl \
     libwebp-dev \
     meson \
     pkg-config \
@@ -57,13 +40,15 @@ RUN \
   curl -s https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor | tee /usr/share/keyrings/nodesource-repo.gpg >/dev/null && \
   apt-get update && \
   apt-get install --no-install-recommends -y \
+    libdav1d7 \
+    libde265-0 \
     libexif12 \
     libexpat1 \
     libgcc-s1 \
     libglib2.0-0 \
     libgomp1 \
     libgsf-1-114 \
-    libheif1 \
+    libio-compress-brotli-perl \
     libjxl0.7 \
     liblcms2-2 \
     liblqr-1-0 \
@@ -104,10 +89,10 @@ RUN \
   ldconfig /usr/lib/jellyfin-ffmpeg/lib && \
   ln -s /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/bin && \
   ln -s /usr/lib/jellyfin-ffmpeg/ffprobe /usr/bin && \
+  ./build-libheif.sh && \
   ./build-libraw.sh && \
   ./build-imagemagick.sh && \
   ./build-libvips.sh && \
-  ./build-perllib-compress-brotli.sh && \
   mkdir -p \
     /app/immich/server && \
   mv \
@@ -134,38 +119,21 @@ RUN \
     autoconf \
     bc \
     build-essential \
-    cpanminus \
+    cmake \
     git \
-    libany-uri-escape-perl \
-    libcapture-tiny-perl \
+    libdav1d-dev \
+    libde265-dev \
     libexif-dev \
     libexpat1-dev \
-    libffi-checklib-perl \
-    libfile-chdir-perl \
-    libfile-slurper-perl \
-    libfile-which-perl \
     libglib2.0-dev \
     libgsf-1-dev \
-    libheif-dev \
-    libio-socket-ssl-perl \
     libjpeg-dev \
     libjxl-dev \
     libltdl-dev \
-    libmojolicious-perl \
-    libnet-ssleay-perl \
     liborc-0.4-dev \
-    libpath-tiny-perl \
-    libpkgconfig-perl \
     librsvg2-dev \
-    libsort-versions-perl \
     libspng-dev \
-    libterm-table-perl \
-    libtest-fatal-perl \
-    libtest-needs-perl \
-    libtest-warnings-perl \
-    libtest2-suite-perl \
     libtool \
-    libtry-tiny-perl \
     libwebp-dev \
     meson \
     pkg-config \
@@ -177,6 +145,5 @@ RUN \
     /tmp/* \
     /var/tmp/* \
     /var/lib/apt/lists/* \
-    /root/.cpanm \
     /etc/apt/sources.list.d/node.list \
     /usr/share/keyrings/nodesource.gpg


### PR DESCRIPTION
remove duplicates, `make` and `g++` which are included in the `build-essential` meta-package
Perl modules is supported with the `libio-compress-brotli-perl` package
Build `libheif` like upstream to support heif files generated with ios18.