### PR TITLE
fix: remoge `pgdg` source list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -178,6 +178,7 @@ RUN \
   apt-get clean && \
   rm -rf \
     /etc/apt/sources.list.d/node.list \
+    /etc/apt/sources.list.d/pgdg.list \
     /tmp/* \
     /usr/share/keyrings/nodesource.gpg \
     /usr/share/keyrings/pgdg-archive-keyring.gpg \


### PR DESCRIPTION
That's causing a build error for the immich docker image