### PR TITLE
#11 fix: remoge `pgdg` source list

### DIFF
--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -161,6 +161,7 @@ RUN \
   apt-get clean && \
   rm -rf \
     /etc/apt/sources.list.d/node.list \
+    /etc/apt/sources.list.d/pgdg.list \
     /tmp/* \
     /usr/share/keyrings/nodesource.gpg \
     /usr/share/keyrings/pgdg-archive-keyring.gpg \


### PR DESCRIPTION
@martabal   I noticed that the "Dockerfile.aarch64" file hasn't fixed this issue, so I added this section.