### PR TITLE
Add postgresql-client-18 to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ RUN \
     postgresql-client-15 \
     postgresql-client-16 \
     postgresql-client-17 \
+    postgresql-client-18 \
     unzip && \
   apt-get install --no-install-recommends -y -t ${LATEST_UBUNTU_VERSION} \
     libdav1d-dev \


### PR DESCRIPTION
Official documentation now confirms support for Postgres 18.

https://github.com/immich-app/immich/discussions/23932
https://docs.immich.app/administration/postgres-standalone/