### PR TITLE
 fix: Install libde265 v1.0.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM ghcr.io/imagegenius/baseimage-ubuntu:noble
 ARG BUILD_DATE
 ARG VERSION
 
-ARG LATEST_UBUNTU_VERSION="questing"
+ARG LATEST_UBUNTU_VERSION="resolute"
 ARG CURRENT_UBUNTU_VERSION="noble"
 
 ARG INTEL_DEPENDENCIES_VERSION="latest"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM ghcr.io/imagegenius/baseimage-ubuntu:noble
 ARG BUILD_DATE
 ARG VERSION
 
-ARG LATEST_UBUNTU_VERSION="plucky"
+ARG LATEST_UBUNTU_VERSION="questing"
 ARG CURRENT_UBUNTU_VERSION="noble"
 
 ARG INTEL_DEPENDENCIES_VERSION="latest"
@@ -37,7 +37,6 @@ RUN \
     git \
     libaom-dev \
     libbrotli-dev \
-    libde265-dev \
     libexif-dev \
     libexpat1-dev \
     libglib2.0-dev \
@@ -58,12 +57,13 @@ RUN \
     unzip && \
   apt-get install --no-install-recommends -y -t ${LATEST_UBUNTU_VERSION} \
     libdav1d-dev \
+    # libde265 v1.0.16 includes a fix for HDR images
+    libde265-dev \
     libhwy-dev \
     libwebp-dev && \
   echo "**** install runtime packages ****" && \
   apt-get install --no-install-recommends -y \
     libdav1d7 \
-    libde265-0 \
     libexif12 \
     libexpat1 \
     libgcc-s1 \
@@ -87,6 +87,7 @@ RUN \
     zlib1g && \
   apt-get install --no-install-recommends -y -t ${LATEST_UBUNTU_VERSION} \
     libaom3 \
+    libde265-0 \
     libhwy1t64 \
     libwebp7 \
     libwebpdemux2 \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -6,7 +6,7 @@ FROM ghcr.io/imagegenius/baseimage-ubuntu:arm64v8-noble
 ARG BUILD_DATE
 ARG VERSION
 
-ARG LATEST_UBUNTU_VERSION="questing"
+ARG LATEST_UBUNTU_VERSION="resolute"
 ARG CURRENT_UBUNTU_VERSION="noble"
 
 LABEL build_version="ImageGenius Version:- ${VERSION} Build-date:- ${BUILD_DATE}"

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -6,7 +6,7 @@ FROM ghcr.io/imagegenius/baseimage-ubuntu:arm64v8-noble
 ARG BUILD_DATE
 ARG VERSION
 
-ARG LATEST_UBUNTU_VERSION="plucky"
+ARG LATEST_UBUNTU_VERSION="questing"
 ARG CURRENT_UBUNTU_VERSION="noble"
 
 LABEL build_version="ImageGenius Version:- ${VERSION} Build-date:- ${BUILD_DATE}"
@@ -32,7 +32,6 @@ RUN \
     git \
     libaom-dev \
     libbrotli-dev \
-    libde265-dev \
     libexif-dev \
     libexpat1-dev \
     libglib2.0-dev \
@@ -49,15 +48,17 @@ RUN \
     postgresql-client-15 \
     postgresql-client-16 \
     postgresql-client-17 \
+    postgresql-client-18 \
     unzip && \
   apt-get install --no-install-recommends -y -t ${LATEST_UBUNTU_VERSION} \
     libdav1d-dev \
+    # libde265 v1.0.16 includes a fix for HDR images
+    libde265-dev \
     libhwy-dev \
     libwebp-dev && \
   echo "**** install runtime packages ****" && \
   apt-get install --no-install-recommends -y \
     libdav1d7 \
-    libde265-0 \
     libexif12 \
     libexpat1 \
     libgcc-s1 \
@@ -81,6 +82,7 @@ RUN \
     zlib1g && \
   apt-get install --no-install-recommends -y -t ${LATEST_UBUNTU_VERSION} \
     libaom3 \
+    libde265-0 \
     libhwy1t64 \
     libwebp7 \
     libwebpdemux2 \


### PR DESCRIPTION
https://github.com/immich-app/base-images/pull/294

Fixes immich-app/immich#21261

Version v1.0.16 is needed with this fix: strukturag/libde265@c7855dd

Because the plucky version only includes libde265 v1.0.15,
I switched to the latest questing version so it can support libde265 v1.0.16,
which fixes the issue.
https://github.com/strukturag/libde265?tab=readme-ov-file#packaging-status

